### PR TITLE
Add Open Telemetry Builder extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Open Telemetry Builder extension.
+- 
+### Changed
+- Renamed `BifrostExporter` to `BifrostExporterExtensions` to match the naming of `OpenTelemetryBuilderExtensions`
+
 ## [0.0.1]
 ### Changed
 - Initial release

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ You can also add your own activity sources and meters.
 ```csharp
 var bifrostOptions = new BifrostOptions
 {
-    bifrostEndpoint: "https://your.bifrost.endpoint/otlp/http/v1",
-    bifrostEnvironmentId: "d9a8719a-8bc2-4829-a078-231df13fd125",
-    identityOptions: new MicrosoftIdentityOptions
+    Endpoint = "https://your.bifrost.endpoint/otlp/http/v1",
+    BifrostEnvironmentId = "d9a8719a-8bc2-4829-a078-231df13fd125",
+    IdentityOptions = new MicrosoftIdentityOptions
         {
             Instance = "https://login.microsoftonline.com/",
             ClientId = "8be5cb8b-3a8d-47bf-9b70-660963b311ef",
             ClientSecret = "ThisIsYourClientSecret",
-            TenantId = "c39886aa-7273-4937-9cad-53b86940713f")
-        });    
+            TenantId = "c39886aa-7273-4937-9cad-53b86940713f"
+        }    
 };
         
 builder.Services.AddOpenTelemetry().UseBifrost(bifrostOptions);

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By using the telemetry builder you'll get
 - `HttpClient` metrics auto instrumentation.
 - `IncludeScopes` and `IncludeFormattedMessage` logs. 
 
-You acn also add your own activity sources and meters.
+You can also add your own activity sources and meters.
 
 ```csharp
 var bifrostOptions = new BifrostOptions
@@ -40,9 +40,9 @@ AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
 
 It is also recommended to configure a Telemetry Resource. Here's an example for the `OpenTelemetryBuilder`:
 ```csharp
-          .ConfigureResource(resourceBuilder => resourceBuilder
-                .AddService("MyServiceName", "MyServiceNamespace")
-          )
+.ConfigureResource(resourceBuilder => resourceBuilder
+      .AddService("MyServiceName", "MyServiceNamespace")
+)
 ```
 Hint: You can also add attributes, like environment, to the resource.
 

--- a/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/BifrostExporterExtensions.cs
+++ b/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/BifrostExporterExtensions.cs
@@ -11,7 +11,7 @@ namespace NovoNordisk.OpenTelemetry.Exporter.Bifrost;
 /// <summary>
 /// Extensions for instrumenting Bifrost exporters in Open Telemetry.
 /// </summary>
-public static class BifrostExporter
+public static class BifrostExporterExtensions
 {
     /// <summary>
     /// Adds a Bifrost exporter the OpenTelemetry log exporter <see cref="ILoggerProvider"/>.

--- a/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/NovoNordisk.OpenTelemetry.Exporter.Bifrost.csproj
+++ b/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/NovoNordisk.OpenTelemetry.Exporter.Bifrost.csproj
@@ -46,6 +46,8 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Identity.Web" Version="2.18.1" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+      <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+      <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     </ItemGroup>
 
 </Project>

--- a/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/OpenTelemetryBuilderExtensions.cs
+++ b/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/OpenTelemetryBuilderExtensions.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace NovoNordisk.OpenTelemetry.Exporter.Bifrost;
+
+/// <summary>
+/// Extensions for instrumenting Bifrost in Open Telemetry.
+/// </summary>
+public static class OpenTelemetryBuilderExtensions
+{
+    /// <summary>
+    /// This extension adds Bifrost exporters to the OpenTelemetryBuilder. Logs, Traces and Metrics are instrumented.
+    /// </summary>
+    /// <param name="builder"><see cref="IOpenTelemetryBuilder"/> builder to use.</param>
+    /// <param name="bifrostOptions">Required options for exporting to Bifrost <see cref="BifrostOptions"/>.</param>
+    /// <returns>The instance of <see cref="IOpenTelemetryBuilder"/> to chain the calls.</returns>
+    public static IOpenTelemetryBuilder UseBifrost(this IOpenTelemetryBuilder builder, BifrostOptions bifrostOptions)
+    {
+        return builder.UseBifrost(bifrostOptions, Array.Empty<string>(), Array.Empty<string>());
+    }
+    
+    /// <summary>
+    /// This extension adds Bifrost exporters to the OpenTelemetryBuilder. Logs, Traces and Metrics are instrumented.
+    /// </summary>
+    /// <param name="builder"><see cref="IOpenTelemetryBuilder"/> builder to use.</param>
+    /// <param name="bifrostOptions">Required options for exporting to Bifrost <see cref="BifrostOptions"/>.</param>
+    /// <param name="activitySourceNames">List of custom activity names. Used to add custom spans to traces.</param>
+    /// <param name="meterNames">List of custom meters.</param>
+    /// <returns>The instance of <see cref="IOpenTelemetryBuilder"/> to chain the calls.</returns>
+    public static IOpenTelemetryBuilder UseBifrost(this IOpenTelemetryBuilder builder, BifrostOptions bifrostOptions,
+        string[] activitySourceNames, string[] meterNames)
+    {
+        builder.WithTracing(tracing =>
+        {
+            tracing
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddSource("Azure.*")
+                .AddSource(activitySourceNames);
+
+            tracing.AddBifrostExporter(bifrostOptions);
+        });
+        
+        builder.WithMetrics(metrics =>
+        {
+            metrics
+                .AddHttpClientInstrumentation()
+                .AddMeter(meterNames);
+            
+            metrics.AddBifrostExporter(bifrostOptions);
+        });
+        
+        builder.Services.AddLogging(logging =>
+        {
+            logging.AddOpenTelemetry(options =>
+            {
+                options.IncludeScopes = true;
+                options.IncludeFormattedMessage = true;
+                options.AddBifrostExporter(bifrostOptions);
+            });
+        });
+        
+        return builder;
+    }
+}


### PR DESCRIPTION
Adds extenstions to the Open Telemetry Builder  so Bifrost can be instrumented like this:

`builder.Services.AddOpenTelemetry().UseBifrost(bifrostOptions);`

Resolves #5 