### PR TITLE
Feature/aspire-inspired-telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.3]
 ### Changed
-- Added `GrpClient` tracing to Open Telemetry Builder extension.
-- Added `AspNetCore`, `Runtime` and `Process` metrics to Open Telemetry Builder extension.
+- Added `AspNetCore` and `Runtime` metrics to Open Telemetry Builder extension.
 
 ## [0.0.2]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.3]
+### Changed
+- Added `GrpClient` tracing to Open Telemetry Builder extension.
+- Added `AspNetCore`, `Runtime` and `Process` metrics to Open Telemetry Builder extension.
+
 ## [0.0.2]
 ### Added
 - Open Telemetry Builder extension.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bifrost can be instrumented in two ways. Either by using the Builder Extensions 
 Using the Open Telemetry Builder extension is the simplest solution but also the least flexible. It is recommended to use the Exporter Extensions if you need more control over the configuration.
 
 By using the telemetry builder you'll get
-- `AspNetCore`, `HttpClient`, and `"Azure.*"` traces auto instrumentation.
+- `AspNetCore`, `HttpClient` and `"Azure.*"` traces auto instrumentation.
 - `HttpClient`, `AspNetCore` and `Runtime` metrics auto instrumentation.
 - `IncludeScopes` and `IncludeFormattedMessage` logs. 
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Bifrost can be instrumented in two ways. Either by using the Builder Extensions 
 Using the Open Telemetry Builder extension is the simplest solution but also the least flexible. It is recommended to use the Exporter Extensions if you need more control over the configuration.
 
 By using the telemetry builder you'll get
-- `AspNetCore`, `HttpClient` and `"Azure.*"` traces auto instrumentation.
-- `HttpClient` metrics auto instrumentation.
+- `AspNetCore`, `HttpClient`, `GrpcClient` and `"Azure.*"` traces auto instrumentation.
+- `HttpClient`, `AspNetCore`, `Process` and `Runtime` metrics auto instrumentation.
 - `IncludeScopes` and `IncludeFormattedMessage` logs. 
 
 You can also add your own activity sources and meters.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Bifrost can be instrumented in two ways. Either by using the Builder Extensions 
 Using the Open Telemetry Builder extension is the simplest solution but also the least flexible. It is recommended to use the Exporter Extensions if you need more control over the configuration.
 
 By using the telemetry builder you'll get
-- `AspNetCore`, `HttpClient`, `GrpcClient` and `"Azure.*"` traces auto instrumentation.
-- `HttpClient`, `AspNetCore`, `Process` and `Runtime` metrics auto instrumentation.
+- `AspNetCore`, `HttpClient`, and `"Azure.*"` traces auto instrumentation.
+- `HttpClient`, `AspNetCore` and `Runtime` metrics auto instrumentation.
 - `IncludeScopes` and `IncludeFormattedMessage` logs. 
 
 You can also add your own activity sources and meters.

--- a/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/NovoNordisk.OpenTelemetry.Exporter.Bifrost.csproj
+++ b/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/NovoNordisk.OpenTelemetry.Exporter.Bifrost.csproj
@@ -47,9 +47,7 @@
       <PackageReference Include="Microsoft.Identity.Web" Version="2.18.2" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
       <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-      <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
       <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-      <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
       <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
     </ItemGroup>
 

--- a/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/NovoNordisk.OpenTelemetry.Exporter.Bifrost.csproj
+++ b/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/NovoNordisk.OpenTelemetry.Exporter.Bifrost.csproj
@@ -47,7 +47,10 @@
       <PackageReference Include="Microsoft.Identity.Web" Version="2.18.2" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
       <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+      <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
       <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+      <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
+      <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
     </ItemGroup>
 
 </Project>

--- a/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/OpenTelemetryBuilderExtensions.cs
+++ b/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/OpenTelemetryBuilderExtensions.cs
@@ -37,7 +37,6 @@ public static class OpenTelemetryBuilderExtensions
         {
             tracing
                 .AddAspNetCoreInstrumentation()
-                .AddGrpcClientInstrumentation()
                 .AddHttpClientInstrumentation()
                 .AddSource("Azure.*")
                 .AddSource(activitySourceNames);
@@ -50,7 +49,6 @@ public static class OpenTelemetryBuilderExtensions
             metrics
                 .AddHttpClientInstrumentation()
                 .AddAspNetCoreInstrumentation()
-                .AddProcessInstrumentation()
                 .AddRuntimeInstrumentation()
                 .AddMeter(meterNames);
             

--- a/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/OpenTelemetryBuilderExtensions.cs
+++ b/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/OpenTelemetryBuilderExtensions.cs
@@ -35,8 +35,15 @@ public static class OpenTelemetryBuilderExtensions
     {
         builder.WithTracing(tracing =>
         {
+            if (builder.Environment.IsDevelopment())
+            {
+                // We want to view all traces in development
+                tracing.SetSampler(new AlwaysOnSampler());
+            }
+
             tracing
                 .AddAspNetCoreInstrumentation()
+                .AddGrpcClientInstrumentation()
                 .AddHttpClientInstrumentation()
                 .AddSource("Azure.*")
                 .AddSource(activitySourceNames);
@@ -48,6 +55,9 @@ public static class OpenTelemetryBuilderExtensions
         {
             metrics
                 .AddHttpClientInstrumentation()
+                .AddAspNetCoreInstrumentation()
+                .AddProcessInstrumentation()
+                .AddRuntimeInstrumentation()
                 .AddMeter(meterNames);
             
             metrics.AddBifrostExporter(bifrostOptions);

--- a/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/OpenTelemetryBuilderExtensions.cs
+++ b/src/NovoNordisk.OpenTelemetry.Exporter.Bifrost/OpenTelemetryBuilderExtensions.cs
@@ -35,12 +35,6 @@ public static class OpenTelemetryBuilderExtensions
     {
         builder.WithTracing(tracing =>
         {
-            if (builder.Environment.IsDevelopment())
-            {
-                // We want to view all traces in development
-                tracing.SetSampler(new AlwaysOnSampler());
-            }
-
             tracing
                 .AddAspNetCoreInstrumentation()
                 .AddGrpcClientInstrumentation()


### PR DESCRIPTION
Added some additional tracing and metrics to the Open Telemetry Builder (`.UseBifrost()`) based on what the Aspire project by Microsoft defaults to for all services. 
I think this would be some good defaults to follow.

For reference: https://github.com/dotnet/aspire/blob/ff9732fafed47140ac38226acdfef4ecd8eb5942/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs#L41